### PR TITLE
Gemspec validation error. TODO keyword has been removed from summary …

### DIFF
--- a/model_pretender.gemspec
+++ b/model_pretender.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = ModelPretender::VERSION
   spec.authors       = ["Alexander Logunov"]
   spec.email         = ["unlovedru@gmail.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Write a short summary. Required.}
+  spec.description   = %q{Write a longer description. Optional.}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
After installing gem, tried to make `rake routes` and got an error:

`The gemspec at ~/.rvm/gems/ruby-2.2.0@floxy/bundler/gems/model_pretender-50ba74cff355/model_pretender.gemspec  is not valid. The validation error was '"FIXME" or "TODO" is not a description`
